### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ A `UIApplication` subclass to start your app off right.
 
 # Setup
 
-1. Install with [Cocoapods](http://cocoapods.org/). Add to your Podfile:
+1. Install with [CocoaPods](http://cocoapods.org/). Add to your Podfile:
 
     ```
     pod 'SSApplication', :head # YOLO


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
